### PR TITLE
feat: configure database connection URL in abax-minuba-server

### DIFF
--- a/resources/kubernetes/deployments/abax-minuba.ts
+++ b/resources/kubernetes/deployments/abax-minuba.ts
@@ -29,6 +29,7 @@ export const serverDeployment = new StandardDeployment(
         .apply(host => `https://${host}`),
       ABAX_CLIENT_ID: config.require('abax-client-id'),
       ABAX_CLIENT_SECRET: config.require('abax-client-secret'),
+      DATABASE_CONNECTION_URL: config.require('database-connection-url'),
     },
     ports: [
       {


### PR DESCRIPTION
This is needed for creating tenants who sign up, storing sessions, and in the future will be needed for reading data from the database (e.g. data about synchronized trips)

TODO
- [ ] Get the actual database connection details (hostname, port, username, password, database name) 