### PR TITLE
fix: set abax minuba ui SELF_URL

### DIFF
--- a/resources/kubernetes/deployments/abax-minuba.ts
+++ b/resources/kubernetes/deployments/abax-minuba.ts
@@ -29,6 +29,9 @@ export const standardDeployment = new StandardDeployment(
       },
     ],
     secretEnv: {
+      SELF_URL: pulumi
+        .output(config.require('frontend-host'))
+        .apply(host => `https://${host}`),
       ABAX_CLIENT_ID: config.require('abax-client-id'),
       ABAX_CLIENT_SECRET: config.require('abax-client-secret'),
     },


### PR DESCRIPTION
For some reason, this env value seems to be `https://localhost:8080/` on the production deployment