### PR TITLE
add minuba api key to secrets

### DIFF
--- a/resources/kubernetes/deployments/abax-minuba.ts
+++ b/resources/kubernetes/deployments/abax-minuba.ts
@@ -31,6 +31,7 @@ export const standardDeployment = new StandardDeployment(
     secretEnv: {
       ABAX_CLIENT_ID: config.require('abax-client-id'),
       ABAX_CLIENT_SECRET: config.require('abax-client-secret'),
+      MINUBA_API_KEY: config.require('minuba-api-key'),
     },
     logLevel: 'debug',
     healthCheckHttpPath: '/',


### PR DESCRIPTION
abax-minuba cronjob needs the minuba api key to run. It is missing from env, so here we are adding that variable