### PR TITLE
fix: remove manual dispatch on todo action

### DIFF
--- a/.github/workflows/create-todo-issues.yml
+++ b/.github/workflows/create-todo-issues.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   todo-to-issue:


### PR DESCRIPTION
`Action can only be used on trigger push or in manual and importAll mode` – the TODO action doesn't work with manual dispatch