### PR TITLE
fix: remove run command from docker compose

### DIFF
--- a/resources/kubernetes/deployments/matrix.ts
+++ b/resources/kubernetes/deployments/matrix.ts
@@ -94,11 +94,7 @@ export const synapseDeployment = new StandardDeployment(
       },
     ],
     // this command is needed to load the secrets and config in two separate files
-    command: [
-      'run',
-      '--config-path=/homeserver.yaml',
-      '--config-path=/secrets.yaml',
-    ],
+    command: ['--config-path=/homeserver.yaml', '--config-path=/secrets.yaml'],
   },
   { providers: [provider] },
 );


### PR DESCRIPTION
fixes this
`
Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "run": executable file not found in $PATH: unknown
`