### PR TITLE
fix: use non-authorative IamMember to prevent conflicts between IAM resources

### DIFF
--- a/resources/google/project.ts
+++ b/resources/google/project.ts
@@ -27,12 +27,12 @@ export const mainProvider = new google.Provider('google-native-main-provider', {
 
 export const googleProviders = [mainClassicProvider, mainProvider];
 
-new gcp.projects.IAMBinding(
+new gcp.projects.IAMMember(
   'main-project-iam-binding',
   {
     project: project.projectId,
     role: 'roles/owner',
-    members: [interpolate`serviceAccount:${config.require('service-account')}`],
+    member: interpolate`serviceAccount:${config.require('service-account')}`,
   },
   { provider: mainClassicProvider },
 );


### PR DESCRIPTION
Using both IamBinding and IamMember on the same role (project wide `roles/owner`) is bound to cause a conflict where the IamBinding wishes to overwrite what is found in the IamMember. The IamMember roles are nevertheless applied. This has caused drift checks to fail since there is always a diff detected, such as in this action run: https://github.com/getbranches/conf/actions/runs/8832184044

See documentation: https://www.pulumi.com/registry/packages/gcp/api-docs/projects/iambinding/