### PR TITLE
fix: use new name for iam member

### DIFF
--- a/resources/google/project.ts
+++ b/resources/google/project.ts
@@ -28,7 +28,7 @@ export const mainProvider = new google.Provider('google-native-main-provider', {
 export const googleProviders = [mainClassicProvider, mainProvider];
 
 new gcp.projects.IAMMember(
-  'main-project-iam-binding',
+  'main-project-iam-member',
   {
     project: project.projectId,
     role: 'roles/owner',


### PR DESCRIPTION
I believe using the same name as the old iam binding is wreaking havoc in the state