### PR TITLE
fix: give cluster access via IAMMember instead of IAMBinding

### DIFF
--- a/resources/config.ts
+++ b/resources/config.ts
@@ -15,5 +15,4 @@ export const callerServiceAccount = googleConfig.require('service-account');
 
 const k8sConfig = new pulumi.Config('kubernetes');
 
-export const clusterDevelopers =
-  k8sConfig.requireObject<string[]>('cluster-developers');
+export const clusterDevelopers = k8sConfig.require('cluster-developers');

--- a/resources/google/iam.ts
+++ b/resources/google/iam.ts
@@ -14,12 +14,12 @@ export const callerClusterIamBinding = new gcp.projects.IAMBinding(
   { provider: mainClassicProvider },
 );
 
-new gcp.projects.IAMBinding(
+new gcp.projects.IAMMember(
   `cluster-developers-cluster-access`,
   {
     project: project.projectId,
     role: 'roles/container.developer',
-    members: clusterDevelopers,
+    member: clusterDevelopers,
   },
   { provider: mainClassicProvider },
 );


### PR DESCRIPTION
in `improved-setup` there is an IAMMember resource with the same role. We can't have a binding and a member on the same role without conflict, so this might resolve some issues we have been seeing regarding access to the k8s cluster